### PR TITLE
Railway deploy fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
         "url-regex-safe": "^3.0.0",
         "wa-sticker-formatter": "^4.3.2", 
         "ws": "^8.11.0", 
-        "yargs": "^17.5.1", 
-        "yt-search": "^2.10.4", 
+        "yargs": "^17.5.1",
         "zs-extract": "^1.4.1"
     }
 }


### PR DESCRIPTION
Yt-search dependency is banned by railway.app 
 so,
Remove it from package.json

Deploy to railway after adding node modules